### PR TITLE
Integration test for VM->ValidatorRetriever

### DIFF
--- a/chains/manager_integration_test.go
+++ b/chains/manager_integration_test.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2019-2021, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+//go:build integration
+// +build integration
+
+package chains
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flare-foundation/flare/ids"
+	"github.com/flare-foundation/flare/snow"
+	"github.com/flare-foundation/flare/snow/validation"
+	"github.com/flare-foundation/flare/utils/logging"
+	"github.com/flare-foundation/flare/vms/rpcchainvm"
+)
+
+func TestManagerIntegration(t *testing.T) {
+	cfg, _ := logging.DefaultConfig()
+	log, _ := logging.NewTestLog(cfg)
+	ctx := &snow.Context{
+		Log: log,
+	}
+
+	vmFactory := &rpcchainvm.Factory{
+		Path: filepath.Join("../build/plugins/mock"),
+	}
+	vm, err := vmFactory.New(ctx)
+	require.NoErrorf(t, err, "if this error occurs during testing, it is most likely that you need to run the `build_plugin_mock.sh` script")
+
+	m := &manager{
+		ManagerConfig: ManagerConfig{
+			Validators: validation.NewSet(),
+		},
+	}
+
+	r, ok := vm.(validation.Retriever)
+	require.True(t, ok)
+	ctx.ValidatorsRetriever = validation.NewCachingRetriever(r)
+	ctx.ValidatorsUpdater = validation.NewUpdater(m.Validators, ctx.ValidatorsRetriever)
+
+	got, err := ctx.ValidatorsRetriever.GetValidators(ids.ID{})
+	require.NoError(t, err)
+
+	assert.Equal(t, got.Len(), 9)
+	for i, v := range got.List() {
+		id := v.ID()
+		assert.Equal(t, byte(i)+1, id[0])
+		assert.Equal(t, uint64(i)+1, v.Weight())
+	}
+}

--- a/chains/manager_integration_test.go
+++ b/chains/manager_integration_test.go
@@ -42,7 +42,7 @@ func TestManagerIntegration(t *testing.T) {
 	r, ok := vm.(validation.Retriever)
 	require.True(t, ok)
 	ctx.ValidatorsRetriever = validation.NewCachingRetriever(r)
-	ctx.ValidatorsUpdater = validation.NewUpdater(m.Validators, ctx.ValidatorsRetriever)
+	ctx.ValidatorsUpdater = validation.NewRetrievingUpdater(m.Validators, ctx.ValidatorsRetriever)
 
 	got, err := ctx.ValidatorsRetriever.GetValidators(ids.ID{})
 	require.NoError(t, err)

--- a/chains/manager_integration_test.go
+++ b/chains/manager_integration_test.go
@@ -47,7 +47,7 @@ func TestManagerIntegration(t *testing.T) {
 	got, err := ctx.ValidatorsRetriever.GetValidators(ids.ID{})
 	require.NoError(t, err)
 
-	assert.Equal(t, got.Len(), 9)
+	assert.Equal(t, got.Len(), 10)
 	for i, v := range got.List() {
 		id := v.ID()
 		assert.Equal(t, byte(i)+1, id[0])

--- a/scripts/build_plugin_mock.sh
+++ b/scripts/build_plugin_mock.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Directory above this script
+FLARE_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+
+# Load the constants
+source "$FLARE_PATH"/scripts/constants.sh
+
+# Build VM Plugin Mock
+echo "Building VM plugin mock..."
+cd "$FLARE_PATH"/testing/mock
+go build -ldflags "$static_ld_flags" -o "$plugin_dir"/mock "plugin/"*.go
+cd "$FLARE_PATH"
+
+# Building coreth + using go get can mess with the go.mod file.
+go mod tidy

--- a/testing/mock/chainvm/mock.go
+++ b/testing/mock/chainvm/mock.go
@@ -1,0 +1,253 @@
+// Copyright (C) 2019-2021, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package chainvm
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/flare-foundation/flare/api/proto/vmproto"
+	"github.com/flare-foundation/flare/database/manager"
+	"github.com/flare-foundation/flare/ids"
+	"github.com/flare-foundation/flare/snow"
+	"github.com/flare-foundation/flare/snow/consensus/snowman"
+	"github.com/flare-foundation/flare/snow/engine/common"
+	"github.com/flare-foundation/flare/snow/validation"
+	"github.com/flare-foundation/flare/version"
+)
+
+type ChainVMMock struct {
+	GetValidatorsFunc func(blockID ids.ID) (validation.Set, error)
+
+	AppRequestFunc           func(nodeID ids.ShortID, requestID uint32, deadline time.Time, request []byte) error
+	AppRequestFailedFunc     func(nodeID ids.ShortID, requestID uint32) error
+	AppResponseFunc          func(nodeID ids.ShortID, requestID uint32, response []byte) error
+	AppGossipFunc            func(nodeID ids.ShortID, msg []byte) error
+	HealthCheckFunc          func() (interface{}, error)
+	ConnectedFunc            func(id ids.ShortID, nodeVersion version.Application) error
+	DisconnectedFunc         func(id ids.ShortID) error
+	InitializeFunc           func(ctx *snow.Context, dbManager manager.Manager, genesisBytes []byte, upgradeBytes []byte, configBytes []byte, toEngine chan<- common.Message, fxs []*common.Fx, appSender common.AppSender) error
+	SetStateFunc             func(state snow.State) error
+	ShutdownFunc             func() error
+	VersionFunc              func() (string, error)
+	CreateStaticHandlersFunc func() (map[string]*common.HTTPHandler, error)
+	CreateHandlersFunc       func() (map[string]*common.HTTPHandler, error)
+	GetBlockFunc             func(ids.ID) (snowman.Block, error)
+	ParseBlockFunc           func([]byte) (snowman.Block, error)
+	BuildBlockFunc           func() (snowman.Block, error)
+	SetPreferenceFunc        func(ids.ID) error
+	LastAcceptedFunc         func() (ids.ID, error)
+}
+
+func (c ChainVMMock) GetValidators(blockID ids.ID) (validation.Set, error) {
+	return c.GetValidatorsFunc(blockID)
+}
+
+func (c ChainVMMock) AppRequest(nodeID ids.ShortID, requestID uint32, deadline time.Time, request []byte) error {
+	return c.AppRequestFunc(nodeID, requestID, deadline, request)
+}
+
+func (c ChainVMMock) AppRequestFailed(nodeID ids.ShortID, requestID uint32) error {
+	return c.AppRequestFailedFunc(nodeID, requestID)
+}
+
+func (c ChainVMMock) AppResponse(nodeID ids.ShortID, requestID uint32, response []byte) error {
+	return c.AppResponseFunc(nodeID, requestID, response)
+}
+
+func (c ChainVMMock) AppGossip(nodeID ids.ShortID, msg []byte) error {
+	return c.AppGossipFunc(nodeID, msg)
+}
+
+func (c ChainVMMock) HealthCheck() (interface{}, error) {
+	return c.HealthCheckFunc()
+}
+
+func (c ChainVMMock) Connected(id ids.ShortID, nodeVersion version.Application) error {
+	return c.ConnectedFunc(id, nodeVersion)
+}
+
+func (c ChainVMMock) Disconnected(id ids.ShortID) error {
+	return c.DisconnectedFunc(id)
+}
+
+func (c ChainVMMock) Initialize(ctx *snow.Context, dbManager manager.Manager, genesisBytes []byte, upgradeBytes []byte, configBytes []byte, toEngine chan<- common.Message, fxs []*common.Fx, appSender common.AppSender) error {
+	return c.InitializeFunc(ctx, dbManager, genesisBytes, upgradeBytes, configBytes, toEngine, fxs, appSender)
+}
+
+func (c ChainVMMock) SetState(state snow.State) error {
+	return c.SetStateFunc(state)
+}
+
+func (c ChainVMMock) Shutdown() error {
+	return c.ShutdownFunc()
+}
+
+func (c ChainVMMock) Version() (string, error) {
+	return c.VersionFunc()
+}
+
+func (c ChainVMMock) CreateStaticHandlers() (map[string]*common.HTTPHandler, error) {
+	return c.CreateStaticHandlersFunc()
+}
+
+func (c ChainVMMock) CreateHandlers() (map[string]*common.HTTPHandler, error) {
+	return c.CreateHandlersFunc()
+}
+
+func (c ChainVMMock) GetBlock(id ids.ID) (snowman.Block, error) {
+	return c.GetBlockFunc(id)
+}
+
+func (c ChainVMMock) ParseBlock(bytes []byte) (snowman.Block, error) {
+	return c.ParseBlockFunc(bytes)
+}
+
+func (c ChainVMMock) BuildBlock() (snowman.Block, error) {
+	return c.BuildBlockFunc()
+}
+
+func (c ChainVMMock) SetPreference(id ids.ID) error {
+	return c.SetPreferenceFunc(id)
+}
+
+func (c ChainVMMock) LastAccepted() (ids.ID, error) {
+	return c.LastAcceptedFunc()
+}
+
+type VMClientMock struct {
+	InitializeFunc           func(ctx context.Context, in *vmproto.InitializeRequest, opts ...grpc.CallOption) (*vmproto.InitializeResponse, error)
+	SetStateFunc             func(ctx context.Context, in *vmproto.SetStateRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	ShutdownFunc             func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	CreateHandlersFunc       func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.CreateHandlersResponse, error)
+	CreateStaticHandlersFunc func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.CreateStaticHandlersResponse, error)
+	ConnectedFunc            func(ctx context.Context, in *vmproto.ConnectedRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	DisconnectedFunc         func(ctx context.Context, in *vmproto.DisconnectedRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	BuildBlockFunc           func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.BuildBlockResponse, error)
+	ParseBlockFunc           func(ctx context.Context, in *vmproto.ParseBlockRequest, opts ...grpc.CallOption) (*vmproto.ParseBlockResponse, error)
+	GetBlockFunc             func(ctx context.Context, in *vmproto.GetBlockRequest, opts ...grpc.CallOption) (*vmproto.GetBlockResponse, error)
+	SetPreferenceFunc        func(ctx context.Context, in *vmproto.SetPreferenceRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	HealthFunc               func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.HealthResponse, error)
+	VersionFunc              func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.VersionResponse, error)
+	AppRequestFunc           func(ctx context.Context, in *vmproto.AppRequestMsg, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	AppRequestFailedFunc     func(ctx context.Context, in *vmproto.AppRequestFailedMsg, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	AppResponseFunc          func(ctx context.Context, in *vmproto.AppResponseMsg, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	AppGossipFunc            func(ctx context.Context, in *vmproto.AppGossipMsg, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	GatherFunc               func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.GatherResponse, error)
+	BlockVerifyFunc          func(ctx context.Context, in *vmproto.BlockVerifyRequest, opts ...grpc.CallOption) (*vmproto.BlockVerifyResponse, error)
+	BlockAcceptFunc          func(ctx context.Context, in *vmproto.BlockAcceptRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	BlockRejectFunc          func(ctx context.Context, in *vmproto.BlockRejectRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	GetAncestorsFunc         func(ctx context.Context, in *vmproto.GetAncestorsRequest, opts ...grpc.CallOption) (*vmproto.GetAncestorsResponse, error)
+	BatchedParseBlockFunc    func(ctx context.Context, in *vmproto.BatchedParseBlockRequest, opts ...grpc.CallOption) (*vmproto.BatchedParseBlockResponse, error)
+	VerifyHeightIndexFunc    func(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.VerifyHeightIndexResponse, error)
+	GetBlockIDAtHeightFunc   func(ctx context.Context, in *vmproto.GetBlockIDAtHeightRequest, opts ...grpc.CallOption) (*vmproto.GetBlockIDAtHeightResponse, error)
+	FetchValidatorsFunc      func(ctx context.Context, in *vmproto.FetchValidatorsRequest, opts ...grpc.CallOption) (*vmproto.FetchValidatorsResponse, error)
+}
+
+func (v VMClientMock) Initialize(ctx context.Context, in *vmproto.InitializeRequest, opts ...grpc.CallOption) (*vmproto.InitializeResponse, error) {
+	return v.InitializeFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) SetState(ctx context.Context, in *vmproto.SetStateRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return v.SetStateFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) Shutdown(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return v.ShutdownFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) CreateHandlers(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.CreateHandlersResponse, error) {
+	return v.CreateHandlersFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) CreateStaticHandlers(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.CreateStaticHandlersResponse, error) {
+	return v.CreateStaticHandlersFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) Connected(ctx context.Context, in *vmproto.ConnectedRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return v.ConnectedFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) Disconnected(ctx context.Context, in *vmproto.DisconnectedRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return v.DisconnectedFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) BuildBlock(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.BuildBlockResponse, error) {
+	return v.BuildBlockFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) ParseBlock(ctx context.Context, in *vmproto.ParseBlockRequest, opts ...grpc.CallOption) (*vmproto.ParseBlockResponse, error) {
+	return v.ParseBlockFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) GetBlock(ctx context.Context, in *vmproto.GetBlockRequest, opts ...grpc.CallOption) (*vmproto.GetBlockResponse, error) {
+	return v.GetBlockFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) SetPreference(ctx context.Context, in *vmproto.SetPreferenceRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return v.SetPreferenceFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) Health(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.HealthResponse, error) {
+	return v.HealthFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) Version(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.VersionResponse, error) {
+	return v.VersionFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) AppRequest(ctx context.Context, in *vmproto.AppRequestMsg, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return v.AppRequestFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) AppRequestFailed(ctx context.Context, in *vmproto.AppRequestFailedMsg, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return v.AppRequestFailedFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) AppResponse(ctx context.Context, in *vmproto.AppResponseMsg, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return v.AppResponseFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) AppGossip(ctx context.Context, in *vmproto.AppGossipMsg, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return v.AppGossipFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) Gather(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.GatherResponse, error) {
+	return v.GatherFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) BlockVerify(ctx context.Context, in *vmproto.BlockVerifyRequest, opts ...grpc.CallOption) (*vmproto.BlockVerifyResponse, error) {
+	return v.BlockVerifyFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) BlockAccept(ctx context.Context, in *vmproto.BlockAcceptRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return v.BlockAcceptFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) BlockReject(ctx context.Context, in *vmproto.BlockRejectRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return v.BlockRejectFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) GetAncestors(ctx context.Context, in *vmproto.GetAncestorsRequest, opts ...grpc.CallOption) (*vmproto.GetAncestorsResponse, error) {
+	return v.GetAncestorsFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) BatchedParseBlock(ctx context.Context, in *vmproto.BatchedParseBlockRequest, opts ...grpc.CallOption) (*vmproto.BatchedParseBlockResponse, error) {
+	return v.BatchedParseBlockFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) VerifyHeightIndex(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*vmproto.VerifyHeightIndexResponse, error) {
+	return v.VerifyHeightIndexFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) GetBlockIDAtHeight(ctx context.Context, in *vmproto.GetBlockIDAtHeightRequest, opts ...grpc.CallOption) (*vmproto.GetBlockIDAtHeightResponse, error) {
+	return v.GetBlockIDAtHeightFunc(ctx, in, opts...)
+}
+
+func (v VMClientMock) FetchValidators(ctx context.Context, in *vmproto.FetchValidatorsRequest, opts ...grpc.CallOption) (*vmproto.FetchValidatorsResponse, error) {
+	return v.FetchValidatorsFunc(ctx, in, opts...)
+}

--- a/testing/mock/plugin/main.go
+++ b/testing/mock/plugin/main.go
@@ -14,7 +14,7 @@ import (
 
 func main() {
 	mockSet := validation.NewSet()
-	for i := 0; i < 10; i++ {
+	for i := 1; i <= 10; i++ {
 		_ = mockSet.AddWeight(fakeShortID(i), uint64(i))
 	}
 

--- a/testing/mock/plugin/main.go
+++ b/testing/mock/plugin/main.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2019-2021, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package main
+
+import (
+	"github.com/hashicorp/go-plugin"
+
+	"github.com/flare-foundation/flare/ids"
+	"github.com/flare-foundation/flare/snow/validation"
+	"github.com/flare-foundation/flare/testing/mock/chainvm"
+	"github.com/flare-foundation/flare/vms/rpcchainvm"
+)
+
+func main() {
+	mock := chainvm.ChainVMMock{
+		GetValidatorsFunc: func(_ ids.ID) (validation.Set, error) {
+			// FIXME: Make this controllable instead of hardcoded.
+			set := validation.NewSet()
+			for i := 0; i < 10; i++ {
+				_ = set.AddWeight(fakeShortID(i), uint64(i))
+			}
+			return set, nil
+		},
+	}
+
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: rpcchainvm.Handshake,
+		Plugins: map[string]plugin.Plugin{
+			"vm": rpcchainvm.New(&mock),
+		},
+
+		// A non-nil value here enables gRPC serving for this plugin...
+		GRPCServer: plugin.DefaultGRPCServer,
+	})
+}
+
+func fakeShortID(i int) ids.ShortID {
+	return ids.ShortID{byte(i), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+}

--- a/testing/mock/plugin/main.go
+++ b/testing/mock/plugin/main.go
@@ -13,14 +13,14 @@ import (
 )
 
 func main() {
+	mockSet := validation.NewSet()
+	for i := 0; i < 10; i++ {
+		_ = mockSet.AddWeight(fakeShortID(i), uint64(i))
+	}
+
 	mock := chainvm.ChainVMMock{
 		GetValidatorsFunc: func(_ ids.ID) (validation.Set, error) {
-			// FIXME: Make this controllable instead of hardcoded.
-			set := validation.NewSet()
-			for i := 0; i < 10; i++ {
-				_ = set.AddWeight(fakeShortID(i), uint64(i))
-			}
-			return set, nil
+			return mockSet, nil
 		},
 	}
 


### PR DESCRIPTION
## Goal of this PR

This PR aims at adding an integration test for everything between the VM plugin and the validator retriever. In order to do that, it adds a new mocked version of `coreth` which is very minimal and only implements the `GetValidators` endpoint.

* Add script to build mocked version of coreth
* Add basic version of coreth mock
* Add integration test which uses the mock binary to create VM and links it to retriever